### PR TITLE
(enhance) Set less as pager for dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN \
 FROM common AS dev-generic
 
 ENV LC_ALL=C
+ENV PAGER=less
 
 RUN \
   apt-get -y update \
@@ -67,6 +68,7 @@ RUN \
   python3-wheel \
   ssh \
   wget \
+  less \
   xz-utils \
   && pip3 install \
   -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-build-test.txt \


### PR DESCRIPTION
This PR sets up less as the pager within the container for developers. Less has a lot more features (like going backwards through output) compared to more.