### PR TITLE
fix(dev-generic): bump curl (to buster-backports)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ ENV LC_ALL=C
 
 RUN \
   apt-get -y update \
-  && apt-get -y install --no-install-recommends \
+  && apt-get -y -t buster-backports install --no-install-recommends \
   curl \
   && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
   && apt-get -y update \


### PR DESCRIPTION
Workaround for dependency conflict ...
```
#7 3.632 The following packages have unmet dependencies:
#7 3.692  curl : Depends: libcurl4 (= 7.64.0-4+deb10u2) but 7.74.0-1.2~bpo10+1 is to be installed
#7 3.703 E: Unable to correct problems, you have held broken packages.
```

This should be reverted once `cmake` no longer comes from `buster-backports`.

See: 5de32f5d1803fc0f86b9fccdc268cc1d10a4b3ff