### PR TITLE
fix: set REPOSITORY_URL to zmkfirmware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ CMD ["/bin/bash"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG REPOSITORY_URL=https://github.com/innovaker/zmk-docker
+ARG REPOSITORY_URL=https://github.com/zmkfirmware/zmk-docker
 LABEL org.opencontainers.image.source ${REPOSITORY_URL}
 
 ARG ZEPHYR_VERSION


### PR DESCRIPTION
This was missed during the original migration from innovaker to zmkfirmware.