### PR TITLE
refactor: Move OCI image.source LABEL out of Dockerfile

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -83,7 +83,8 @@ jobs:
             ZEPHYR_VERSION=${{ env.zephyr-version }}
             ARCHITECTURE=${{ matrix.architecture }}
             ZEPHYR_SDK_VERSION=${{ env.zephyr-sdk-version }}
-            REPOSITORY_URL=${{ github.server_url }}/${{ github.repository }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           tags: |
             docker.io/${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ steps.vars.outputs.candidate-tag }}
           cache-from: type=registry,ref=docker.io/${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ steps.vars.outputs.cache-from }},push=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ CMD ["/bin/bash"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG REPOSITORY_URL=https://github.com/innovaker/zmk-docker
-LABEL org.opencontainers.image.source ${REPOSITORY_URL}
-
 ARG ZEPHYR_VERSION
 ENV ZEPHYR_VERSION=${ZEPHYR_VERSION}
 RUN \


### PR DESCRIPTION
Defining the LABEL via an ARG at the top of the Dockerfile prevents other GitHub repositories (or local Docker users) from leveraging otherwise identical cache layers.