### PR TITLE
refactor: remove push from cache-from and cache-to and simplify boilerplating

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -39,11 +39,6 @@ jobs:
           NAME=zmk-${{ matrix.target }}-${{ matrix.architecture }}
           echo ::set-output name=name::${NAME}
 
-          CACHE_FROM=${{ env.cache-repository-name }}:dev
-          CACHE_TO=${{ env.cache-repository-name }}:${{ matrix.target }}
-          echo ::set-output name=cache-from::${CACHE_FROM}
-          echo ::set-output name=cache-to::${CACHE_TO}
-
           CANDIDATE_TAG=${NAME}:${{ github.sha }}
           echo ::set-output name=candidate-tag::${CANDIDATE_TAG}
 
@@ -80,8 +75,8 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           tags: |
             docker.io/${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ steps.vars.outputs.candidate-tag }}
-          cache-from: type=registry,ref=docker.io/${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ steps.vars.outputs.cache-from }}
-          cache-to: type=registry,ref=docker.io/${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ steps.vars.outputs.cache-to }},mode=max
+          cache-from: type=registry,ref=docker.io/${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ env.cache-repository-name }}:dev
+          cache-to: type=registry,ref=docker.io/${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ env.cache-repository-name }}:${{ matrix.target }},mode=max
           push: true
       - name: Image digest
         if: ${{ !startsWith(github.ref, 'refs/tags') }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -20,11 +20,6 @@ jobs:
         target: # ordered from biggest to smallest to take advantage of the registry cache
           - dev
           - build
-        include:
-          - target: dev
-            cache-to: dev
-          - target: build
-            cache-to: build
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -45,7 +40,7 @@ jobs:
 
           CACHE_NAME=zmk-docker-cache
           CACHE_FROM=${CACHE_NAME}:dev
-          CACHE_TO=${CACHE_NAME}:${{ matrix.cache-to }}
+          CACHE_TO=${CACHE_NAME}:${{ matrix.target }}
           echo ::set-output name=cache-from::${CACHE_FROM}
           echo ::set-output name=cache-to::${CACHE_TO}
 

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -3,6 +3,7 @@ name: Containers
 env:
   zephyr-version: 2.4.0
   zephyr-sdk-version: 0.11.4
+  cache-repository-name: zmk-docker-cache
 
 on:
   push:
@@ -38,9 +39,8 @@ jobs:
           NAME=zmk-${{ matrix.target }}-${{ matrix.architecture }}
           echo ::set-output name=name::${NAME}
 
-          CACHE_NAME=zmk-docker-cache
-          CACHE_FROM=${CACHE_NAME}:dev
-          CACHE_TO=${CACHE_NAME}:${{ matrix.target }}
+          CACHE_FROM=${{ env.cache-repository-name }}:dev
+          CACHE_TO=${{ env.cache-repository-name }}:${{ matrix.target }}
           echo ::set-output name=cache-from::${CACHE_FROM}
           echo ::set-output name=cache-to::${CACHE_TO}
 

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -23,10 +23,8 @@ jobs:
         include:
           - target: dev
             cache-to: dev
-            push-cache: true
           - target: build
             cache-to: build
-            push-cache: false
     steps:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -87,8 +85,8 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           tags: |
             docker.io/${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ steps.vars.outputs.candidate-tag }}
-          cache-from: type=registry,ref=docker.io/${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ steps.vars.outputs.cache-from }},push=false
-          cache-to: type=registry,ref=docker.io/${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ steps.vars.outputs.cache-to }},mode=max,push=${{ matrix.push-cache }}
+          cache-from: type=registry,ref=docker.io/${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ steps.vars.outputs.cache-from }}
+          cache-to: type=registry,ref=docker.io/${{ secrets.DOCKER_HUB_NAMESPACE }}/${{ steps.vars.outputs.cache-to }},mode=max
           push: true
       - name: Image digest
         if: ${{ !startsWith(github.ref, 'refs/tags') }}


### PR DESCRIPTION
I ran some tests and it seems that `push` is meaningless in the context of docker build's `cache-from` or `cache-to`.  Whoops!

The caching still worked, it just unnecessarily pushed out the `build` cache instead of just the `dev` cache.

This PR removes anything superfluous and simplifies the relevant boilerplating.