### PR TITLE
refactor: remove `build` registry cache

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -92,7 +92,7 @@ jobs:
           tags: |
             docker.io/${{ steps.vars.outputs.docker-hub-namespace }}/${{ steps.vars.outputs.candidate-tag }}
           cache-from: type=registry,ref=docker.io/${{ steps.vars.outputs.docker-hub-namespace }}/${{ env.cache-repository-name }}:dev
-          cache-to: ${{ (steps.docker-hub-login.outcome == 'success') && format('type=registry,ref=docker.io/{0}/{1}:{2},mode=max', steps.vars.outputs.docker-hub-namespace, env.cache-repository-name, matrix.target) || null }}
+          cache-to: ${{ (steps.docker-hub-login.outcome == 'success') && (matrix.target == 'dev') && format('type=registry,ref=docker.io/{0}/{1}:{2},mode=max', steps.vars.outputs.docker-hub-namespace, env.cache-repository-name, 'dev') || null }}
           push: ${{ steps.docker-hub-login.outcome == 'success' }}
       - name: Image digest
         if: ${{ !startsWith(github.ref, 'refs/tags') }}


### PR DESCRIPTION
`build` is a subset of `dev`, so there's no need to save both to the registry with `mode=max`