### PR TITLE
feat: restrict concurrency per workflow

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency: ${{ github.workflow }}
+    
 jobs:
   docker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This protects the cache from competing workflow runs.