### PR TITLE
fix: add guard conditions for west build tests

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -367,11 +367,14 @@ jobs:
       - name: Test west zephyr-export
         run: west zephyr-export
       - name: Test board/shield (west build)
+        id: board-shield
         if: ${{ matrix.board != null }}
         run: west build -s app -b ${{ matrix.board }} -- ${{ matrix.shield != null && format('-DSHIELD={0}', matrix.shield) || null }}
       - name: Test RAM report (west build)
+        if: ${{ steps.board-shield.outcome == 'success' }}
         run: west build -t ram_report
       - name: Test ROM report (west build)
+        if: ${{ steps.board-shield.outcome == 'success' }}
         run: west build -t rom_report
       - name: Test west test (single)
         run: west test tests/none/normal
@@ -379,6 +382,7 @@ jobs:
         if: ${{ env.run-unit-tests == 'true' }}
         run: west test
       - name: Test clean (west build)
+        if: ${{ steps.board-shield.outcome == 'success' }}
         run: west build -t clean
       - name: Stop container
         shell: bash


### PR DESCRIPTION
The RAM report, ROM report and clean steps depend on the success of the board/shield build.

Otherwise it complains with either ...
```
ERROR: source directory "." does not contain a CMakeLists.txt; is this really what you want to build? (Use -s SOURCE_DIR to specify the application source directory)
FATAL ERROR: refusing to proceed without --force due to above error
```
... when the working directory is the ZMK repository root,
or ...
```
WARNING: This looks like a fresh build and BOARD is unknown; so it probably won't work. To fix, use --board=<your-board>.
Note: to silence the above message, run 'west config build.board_warn false'
-- west build: generating a build system
CMake Error at cmake/zmk_config.cmake:144 (message):
  Failed to locate keymap file!
Call Stack (most recent call first):
  CMakeLists.txt:14 (include)


-- Configuring incomplete, errors occurred!
FATAL ERROR: command exited with status 1: /usr/bin/cmake -DWEST_PYTHON=/usr/bin/python3 -B/github/workspace/app/build -S/github/workspace/app -GNinja
Error: Process completed with exit code 1.
```
... when the working directory is `app`.

This "fix" introduces guard conditions based on the success of the board/shield step.  It's possible that these can be reverted in the future after further exploration.