### PR TITLE
feat: replace sequential jobs with concurrent jobs

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -190,7 +190,6 @@ jobs:
       run:
         shell: /usr/bin/docker exec candidate /bin/bash {0}
     strategy:
-      max-parallel: 1 # takes advantage of caching between jobs
       matrix: 
         architecture: ${{ fromJSON(needs.architectures.outputs.json) }}
         include:


### PR DESCRIPTION
`max-parallel: 1` is no longer necessary.

Requires #56.