### PR TITLE
feat: add remaining 0.11.4 architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,23 @@ Lightweight Docker images for [ZMK][zmk].
 
 ### Platforms
 
+#### Tested
 - `arm`
+
+#### Not Tested
+- `arc`
+- `arm64`
+- `nios2`
+- `riscv64`
+- `sparc`
+- `x86_64`
+- `xtensa_intel_apl_adsp`
+- `xtensa_intel_bdw_adsp`
+- `xtensa_intel_byt_adsp`
+- `xtensa_intel_s1000`
+- `xtensa_nxp_imx8m_adsp`
+- `xtensa_nxp_imx_adsp`
+- `xtensa_sample_controller`
 
 ### Images
 

--- a/architectures.yml
+++ b/architectures.yml
@@ -1,1 +1,14 @@
+- arc
 - arm
+- arm64
+- nios2
+- riscv64
+- sparc
+- x86_64
+- xtensa_intel_apl_adsp
+- xtensa_intel_bdw_adsp
+- xtensa_intel_byt_adsp
+- xtensa_intel_s1000
+- xtensa_nxp_imx8m_adsp
+- xtensa_nxp_imx_adsp
+- xtensa_sample_controller


### PR DESCRIPTION
Recent design improvements permit building all of Zephyr's supported architectures simultaneously.  So why not?

Requires #56 and #57.