### PR TITLE
feat: add cache-from dev-generic (GitHub Actions cache)

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -70,10 +70,91 @@ jobs:
           echo ::set-output name=major-minor::${MAJOR_MINOR}
           echo ::set-output name=latest::${LATEST}
           echo ::set-output name=release-trigger::${RELEASE_TRIGGER}
+  dev-generic:
+    needs:
+      - tags
+    if: ${{ !startsWith(github.ref, 'refs/tags') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        id: docker-hub-login
+        if: ${{ env.docker-hub-credentials == 'true' }}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        id: ghcr-login
+        if: ${{ env.ghcr-credentials == 'true' }}
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Define paths
+        id: paths
+        env:
+          NS: ${{ env.docker-hub-namespace }}
+          REPOSITORY: zmk-dev-generic-cache
+          BRANCH: ${{ needs.tags.outputs.branch }}
+          BASE: ${{ needs.tags.outputs.base }}
+        run: |
+          echo ::set-output name=local::/tmp/.buildx/dev-generic
+          echo ::set-output name=local-new::/tmp/.buildx/dev-generic-new
+          echo ::set-output name=branch::docker.io/${NS}/${REPOSITORY}:${BRANCH}
+          if [ ! -z "$BASE" ]; then
+            echo ::set-output name=base::docker.io/${NS}/${REPOSITORY}:${BASE}
+          fi
+      - name: Set up cache
+        id: cache
+        uses: actions/cache@v2
+        env:
+          cache-name: dev-generic
+        with:
+          path: ${{ steps.paths.outputs.local }}
+          key: ${{ runner.os }}/${{ env.cache-name }}/${{ github.run_id }}
+      - name: Rebuild cache?
+        id: should-rebuild
+        run: echo ::set-output name=value::${{ steps.cache.outputs.cache-hit != 'true' }}
+      - name: Set up QEMU
+        if: ${{ steps.should-rebuild.outputs.value == 'true' }}
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        if: ${{ steps.should-rebuild.outputs.value == 'true' }}
+        uses: docker/setup-buildx-action@v1
+      - name: Build to local cache
+        if: ${{ steps.should-rebuild.outputs.value == 'true' }}
+        uses: docker/build-push-action@v2
+        with:
+          target: dev-generic
+          build-args: |
+            ZEPHYR_VERSION=${{ env.zephyr-version }}
+          cache-from: |
+            type=registry,ref=${{ steps.paths.outputs.branch }}
+            ${{ (steps.paths.outputs.base != '') && format('type=registry,ref={0}', steps.paths.outputs.base) || '' }}
+          cache-to: type=local,dest=${{ steps.paths.outputs.local-new }},mode=max
+      - name: Push to registry cache
+        if: ${{ (steps.should-rebuild.outputs.value == 'true') && (env.docker-hub-credentials == 'true') }}
+        uses: docker/build-push-action@v2
+        with:
+          target: dev-generic
+          build-args: |
+            ZEPHYR_VERSION=${{ env.zephyr-version }}
+          cache-from: type=local,src=${{ steps.paths.outputs.local-new }}
+          cache-to: type=registry,ref=${{ steps.paths.outputs.branch }},mode=max
+      # Workaround to stop the dev-generic cache ballooning ...
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Switch local cache
+        if: ${{ steps.should-rebuild.outputs.value == 'true' }}
+        run: |
+          rm -rf ${{ steps.paths.outputs.local }}
+          mv ${{ steps.paths.outputs.local-new }} ${{ steps.paths.outputs.local }}
   candidates:
     needs:
       - architectures
       - tags
+      - dev-generic
     if: ${{ !startsWith(github.ref, 'refs/tags') }}
     runs-on: ubuntu-latest
     env:
@@ -122,6 +203,7 @@ jobs:
           BRANCH: ${{ needs.tags.outputs.branch }}
           BASE: ${{ needs.tags.outputs.base }}
         run: |
+          echo ::set-output name=dev-generic::/tmp/.buildx/dev-generic
           echo ::set-output name=build-candidate::docker.io/${NS}/${BUILD}:${CANDIDATE}
           echo ::set-output name=build-branch::docker.io/${NS}/${BUILD}:${BRANCH}
           if [ ! -z "$BASE" ]; then
@@ -161,6 +243,14 @@ jobs:
           LIST="${LIST//$'\n'/'%0A'}"
           LIST="${LIST//$'\r'/'%0D'}"
           echo ::set-output name=list::${LIST}
+      - name: Set up dev-generic cache
+        id: dev-generic-cache
+        uses: actions/cache@v2
+        env:
+          cache-name: dev-generic
+        with:
+          path: ${{ steps.paths.outputs.dev-generic }}
+          key: ${{ runner.os }}/${{ env.cache-name }}/${{ github.run_id }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -177,6 +267,7 @@ jobs:
             ${{ steps.paths.outputs.build-candidate }}
             ${{ steps.paths.outputs.build-branch }}
           cache-from: |
+            type=local,src=${{ steps.paths.outputs.dev-generic }}
             type=registry,ref=${{ steps.paths.outputs.build-candidate }}
             type=registry,ref=${{ steps.paths.outputs.build-branch }}
             ${{ (steps.paths.outputs.build-base != '') && format('type=registry,ref={0}', steps.paths.outputs.build-base) || '' }}
@@ -195,6 +286,7 @@ jobs:
             ${{ steps.paths.outputs.dev-branch }}
           cache-from: |
             type=registry,ref=${{ steps.paths.outputs.build-candidate }}
+            type=local,src=${{ steps.paths.outputs.dev-generic }}
             type=registry,ref=${{ steps.paths.outputs.dev-candidate }}
             type=registry,ref=${{ steps.paths.outputs.dev-branch }}
             ${{ (steps.paths.outputs.dev-base != '') && format('type=registry,ref={0}', steps.paths.outputs.dev-base) || '' }}


### PR DESCRIPTION
Pre-builds the dev-generic stage and provides it to all subsequent jobs.  This improves the integrity between the jobs within a particular workflow run, especially in the absence of registry credentials.  It also improves build times for multiple architectures when the early stages are changed/invalidated.

Builds on #60.