### PR TITLE
feat: schedule workflow to run nightly at 02:00 UTC

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -3,7 +3,7 @@ name: Containers
 env:
   zephyr-version: 2.4.0
   zephyr-sdk-version: 0.11.4
-  no-cache: ${{ github.event_name == 'workflow_dispatch' }}
+  no-cache: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
   run-unit-tests: ${{ secrets.RUN_UNIT_TESTS != null }}
   docker-hub-credentials: ${{ secrets.DOCKER_HUB_USERNAME != null && secrets.DOCKER_HUB_TOKEN != null }}
   ghcr-credentials: ${{ secrets.GHCR_USERNAME != null && secrets.GHCR_TOKEN != null }}
@@ -17,6 +17,8 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *' # every day at 02:00 UTC
 
 concurrency: ${{ github.ref }}/${{ github.workflow }}
 


### PR DESCRIPTION
Rebuilds the default branch from scratch every night.  This ensures that the latest security patches are available for testers.

Requires: #65