### PR TITLE
refactor(dev-generic): remove `node --version` from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,7 @@ RUN \
   -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-build-test.txt \
   -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-run-test.txt \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* \
-  && node --version
+  && rm -rf /var/lib/apt/lists/*
 
 ENV DEBIAN_FRONTEND=
 


### PR DESCRIPTION
This line in the Dockerfile has been superseded by the tests.

See: 70e225f229aece7e553f9f868e603d09566efa3f