### PR TITLE
refactor(common): remove `cmake --version` from Dockerfile to tests

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -341,6 +341,8 @@ jobs:
       - name: Create and run container from 'build' candidate image
         shell: bash
         run: docker run -d -it --name candidate ${{ env.docker-args }} ${{ steps.paths.outputs.build-candidate }}
+      - name: Test cmake
+        run: cmake --version
       - name: Test diff
         run: diff --version
       - name: Test west init

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ RUN \
   python3-setuptools \
   python3-wheel \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* \
-  && cmake --version
+  && rm -rf /var/lib/apt/lists/*
 
 #------------------------------------------------------------------------------
 


### PR DESCRIPTION
Makes it easier to check the `cmake` version when the layer is already cached.