### PR TITLE
refactor: always rebuild `dev-generic`

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -88,6 +88,7 @@ jobs:
           echo ::set-output name=major-minor-branch::${MAJOR_MINOR_BRANCH}
   dev-generic:
     needs:
+      - timestamp
       - tags
     if: ${{ !startsWith(github.ref, 'refs/tags') }}
     runs-on: ubuntu-latest
@@ -133,18 +134,14 @@ jobs:
           cache-name: dev-generic
         with:
           path: ${{ steps.paths.outputs.local }}
-          key: ${{ runner.os }}/${{ env.cache-name }}/${{ github.run_id }}
-      - name: Rebuild cache?
-        id: should-rebuild
-        run: echo ::set-output name=value::${{ steps.cache.outputs.cache-hit != 'true' || env.no-cache == 'true' }}
+          key: ${{ runner.os }}/${{ env.cache-name }}/${{ github.run_id }}/${{ needs.timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ runner.os }}/${{ env.cache-name }}/${{ github.run_id }}
       - name: Set up QEMU
-        if: ${{ steps.should-rebuild.outputs.value == 'true' }}
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
-        if: ${{ steps.should-rebuild.outputs.value == 'true' }}
         uses: docker/setup-buildx-action@v1
       - name: Build to local cache
-        if: ${{ steps.should-rebuild.outputs.value == 'true' }}
         uses: docker/build-push-action@v2
         with:
           target: dev-generic
@@ -152,6 +149,7 @@ jobs:
             ZEPHYR_VERSION=${{ env.zephyr-version }}
           no-cache: ${{ env.no-cache == 'true' }}
           cache-from: |
+            type=local,src=${{ steps.paths.outputs.local }}
             type=registry,ref=${{ steps.paths.outputs.branch }}
             ${{ (steps.paths.outputs.base != '') && format('type=registry,ref={0}', steps.paths.outputs.base) || '' }}
             type=registry,ref=${{ steps.paths.outputs.major-minor-branch }}
@@ -159,7 +157,7 @@ jobs:
             type=registry,ref=${{ steps.paths.outputs.major-minor-branch-upstream }}
           cache-to: type=local,dest=${{ steps.paths.outputs.local-new }},mode=max
       - name: Push to registry cache
-        if: ${{ (steps.should-rebuild.outputs.value == 'true') && (env.docker-hub-credentials == 'true') }}
+        if: ${{ env.docker-hub-credentials == 'true' }}
         uses: docker/build-push-action@v2
         with:
           target: dev-generic
@@ -174,12 +172,12 @@ jobs:
       # https://github.com/docker/build-push-action/issues/252
       # https://github.com/moby/buildkit/issues/1896
       - name: Switch local cache
-        if: ${{ steps.should-rebuild.outputs.value == 'true' }}
         run: |
           rm -rf ${{ steps.paths.outputs.local }}
           mv ${{ steps.paths.outputs.local-new }} ${{ steps.paths.outputs.local }}
   candidates:
     needs:
+      - timestamp
       - architectures
       - tags
       - dev-generic
@@ -286,7 +284,7 @@ jobs:
           cache-name: dev-generic
         with:
           path: ${{ steps.paths.outputs.dev-generic }}
-          key: ${{ runner.os }}/${{ env.cache-name }}/${{ github.run_id }}
+          key: ${{ runner.os }}/${{ env.cache-name }}/${{ github.run_id }}/${{ needs.timestamp.outputs.timestamp }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -24,6 +24,14 @@ on:
 concurrency: ${{ github.ref }}/${{ github.workflow }}
 
 jobs:
+  timestamp:
+    runs-on: ubuntu-latest
+    outputs:
+      timestamp: ${{ steps.timestamp.outputs.timestamp }}
+    steps:
+      - name: Timestamp
+        id: timestamp
+        run: echo ::set-output name=timestamp::$(date +%Y%m%d%H%M%S)
   architectures:
     runs-on: ubuntu-latest
     outputs:
@@ -40,6 +48,8 @@ jobs:
             architectures = yaml.safe_load(file)
             print('::set-output name=json::' + json.dumps(architectures))
   tags:
+    needs:
+      - timestamp
     runs-on: ubuntu-latest
     outputs:
       branch: ${{ steps.definitions.outputs.branch }}
@@ -52,6 +62,7 @@ jobs:
       - name: Definitions
         id: definitions
         env:
+          TIMESTAMP: ${{ needs.timestamp.outputs.timestamp }}
           SHA: ${{ github.sha }}
           SHA_ABBREV_LENGTH: ${{ env.sha-abbrev-length }}
           RUN_ID: ${{ github.run_id }}
@@ -62,7 +73,7 @@ jobs:
           BRANCH=${BRANCH//[^A-Za-z0-9_.-]/_} # Substitutes invalid Docker tag characters
           BASE=${GITHUB_BASE_REF//[^A-Za-z0-9_.-]/_} # Substitutes invalid Docker tag characters
           SHA=${SHA:0:${SHA_ABBREV_LENGTH}}
-          CANDIDATE=${BRANCH}-$(date +%Y%m%d%H%M%S)-${ZEPHYR_VERSION}-${ZEPHYR_SDK_VERSION}-${SHA}-${RUN_ID}
+          CANDIDATE=${BRANCH}-${TIMESTAMP}-${ZEPHYR_VERSION}-${ZEPHYR_SDK_VERSION}-${SHA}-${RUN_ID}
           VERSIONS=${ZEPHYR_VERSION}-${ZEPHYR_SDK_VERSION}
           MAJOR=$(echo ${ZEPHYR_VERSION} | cut -d'.' -f 1)
           MINOR=$(echo ${ZEPHYR_VERSION} | cut -d'.' -f 2)


### PR DESCRIPTION
The `dev-generic` job was originally designed to only build once per workflow run, which included re-runs.  This unfortunately made it difficult to recreate and inspect dev-generic cache problems post-merge.  This change removes this optimization.