### PR TITLE
feat(dev-generic): add `ENV ZEPHYR_SDK_VERSION`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,9 @@ RUN \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
+ARG ZEPHYR_SDK_VERSION
+ENV ZEPHYR_SDK_VERSION=${ZEPHYR_SDK_VERSION}
+
 ENV DEBIAN_FRONTEND=
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Lets scripts (outside the Zephyr bubble) find the SDK.