### PR TITLE
refactor: increase webpack-dev-server timeout by 10 seconds

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -401,8 +401,8 @@ jobs:
       - name: Test docs prettier check
         run: cd docs && npm run prettier:check
       - name: Test docs start (webpack-dev-server)
-        run: cd docs && timeout -s SIGINT 20 npm run start &
-      - run: sleep 15
+        run: cd docs && timeout -s SIGINT 30 npm run start &
+      - run: sleep 25
       - name: Test docs wget (webpack-dev-server)
         run: wget http://localhost:3000
       - run: sleep 10


### PR DESCRIPTION
The webpack-dev-server wget test occasionally fails to find the server.  Increasing the start (build) time allowance may fix the problem.