### PR TITLE
refactor: remove `ZEPHYR_SDK_VERSION` from Zephyr SDK path

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -423,7 +423,7 @@ jobs:
         run: gdb --version
       - name: Test arm-zephyr-eabi-gdb
         if: ${{ matrix.architecture == 'arm' }}
-        run: /opt/zephyr-sdk-${ZEPHYR_SDK_VERSION}/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb --version
+        run: /opt/zephyr-sdk/arm-zephyr-eabi/bin/arm-zephyr-eabi-gdb --version
       - name: Test tio
         run: tio --version
       - name: Test socat

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,7 +86,7 @@ FROM common AS build
 ARG ARCHITECTURE
 ARG ZEPHYR_SDK_VERSION
 ARG ZEPHYR_SDK_SETUP_FILENAME=zephyr-toolchain-${ARCHITECTURE}-${ZEPHYR_SDK_VERSION}-x86_64-linux-setup.run
-ARG ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-sdk-${ZEPHYR_SDK_VERSION}
+ARG ZEPHYR_SDK_INSTALL_DIR=/opt/zephyr-sdk
 RUN \
   apt-get -y update \
   && apt-get -y install --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,9 +74,6 @@ RUN \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-ARG ZEPHYR_SDK_VERSION
-ENV ZEPHYR_SDK_VERSION=${ZEPHYR_SDK_VERSION}
-
 ENV DEBIAN_FRONTEND=
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This provides a consistent environment between releases which is easier to script.