### PR TITLE
Deps/remove multilib after native posix 64 move

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,10 @@ ARG ZEPHYR_VERSION
 ENV ZEPHYR_VERSION=${ZEPHYR_VERSION}
 RUN \
   apt-get -y update \
-  && if [ "$(uname -m)" = "x86_64" ]; then gcc_multilib="gcc-multilib"; else gcc_multilib=""; fi \
   && apt-get -y install --no-install-recommends \
   ccache \
   file \
   gcc \
-  "${gcc_multilib}" \
   git \
   gperf \
   make \


### PR DESCRIPTION
ZMK will move to the previously unavailable `native_posix_64` board target for tests, etc. and that means we no longer need the `gcc-multilib` dependency for our docker images.

Remove it!