### PR TITLE
feat: Use `skopeo copy` to create multi-arch tags.

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -560,6 +560,8 @@ jobs:
           - build
           - dev
     steps:
+      - name: Install skopeo
+        run: sudo apt-get install -y skopeo
       - name: Login to GitHub Container Registry
         id: ghcr-login
         uses: docker/login-action@v1
@@ -585,18 +587,11 @@ jobs:
         run: |
           REPOSITORY=zmk-${TARGET}-${ARCHITECTURE}
           
-          docker pull docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE}
-          docker tag docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE} docker.io/${DHNS}/${REPOSITORY}:${VERSIONS}
-          docker tag docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE} docker.io/${DHNS}/${REPOSITORY}:${MAJOR_MINOR}
-          docker tag docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE} ghcr.io/${GHCRNS}/${REPOSITORY}:${CANDIDATE}
-          docker tag docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE} ghcr.io/${GHCRNS}/${REPOSITORY}:${VERSIONS}
-          docker tag docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE} ghcr.io/${GHCRNS}/${REPOSITORY}:${MAJOR_MINOR}
-          docker push docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE}
-          docker push docker.io/${DHNS}/${REPOSITORY}:${VERSIONS}
-          docker push docker.io/${DHNS}/${REPOSITORY}:${MAJOR_MINOR}
-          docker push ghcr.io/${GHCRNS}/${REPOSITORY}:${CANDIDATE}
-          docker push ghcr.io/${GHCRNS}/${REPOSITORY}:${VERSIONS}
-          docker push ghcr.io/${GHCRNS}/${REPOSITORY}:${MAJOR_MINOR}
+          skopeo copy --all docker://docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE} docker://docker.io/${DHNS}/${REPOSITORY}:${VERSIONS}
+          skopeo copy --all docker://docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE} docker://docker.io/${DHNS}/${REPOSITORY}:${MAJOR_MINOR}
+          skopeo copy --all docker://docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE} docker://ghcr.io/${GHCRNS}/${REPOSITORY}:${CANDIDATE}
+          skopeo copy --all docker://docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE} docker://ghcr.io/${GHCRNS}/${REPOSITORY}:${VERSIONS}
+          skopeo copy --all docker://docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE} docker://ghcr.io/${GHCRNS}/${REPOSITORY}:${MAJOR_MINOR}
   git-tag:
     needs:
     - tags
@@ -643,6 +638,8 @@ jobs:
           - build
           - dev
     steps:
+      - name: Install skopeo
+        run: sudo apt-get install -y skopeo
       - name: Login to GitHub Container Registry
         id: ghcr-login
         uses: docker/login-action@v1
@@ -666,10 +663,7 @@ jobs:
         run: |
           REPOSITORY=zmk-${TARGET}-${ARCHITECTURE}
           
-          docker pull docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE}
-          docker tag docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE} docker.io/${DHNS}/${REPOSITORY}:stable
-          
-          docker push docker.io/${DHNS}/${REPOSITORY}:stable
+          skopeo copy --all docker://docker.io/${DHNS}/${REPOSITORY}:${CANDIDATE} docker://docker.io/${DHNS}/${REPOSITORY}:stable
   stable-git-tag:
     needs:
     - tags


### PR DESCRIPTION
* Avoid plain `docker tag` to create stable/versioned tags, as this
  creates single architecture image tags, instead of a new manifest list
* Use `skopeo copy` instead for this!