### PR TITLE
refactor: Move to new NodeSource install approach.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,10 @@ ENV PAGER=less
 RUN \
   apt-get -y update \
   && apt-get -y install --no-install-recommends \
-  curl \
-  && curl -sL https://deb.nodesource.com/setup_18.x | bash - \
+  curl ca-certificates gnupg \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
   && apt-get -y update \
   && apt-get -y install --no-install-recommends \
   clang-format \


### PR DESCRIPTION
* Move away from deprecated install bash script in favor of the current recommended steps in https://github.com/nodesource/distributions#installation-instructions