### PR TITLE
fix(devcontainer): Add packages required by grpcio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ RUN \
   && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
   && apt-get -y update \
   && apt-get -y install --no-install-recommends \
+  build-essential \
   clang-format \
   gdb \
   gpg \
@@ -97,7 +98,7 @@ RUN \
   && apt-get -y install --no-install-recommends \
   wget \
   xz-utils \
-  && cd ${TMP} \ 
+  && cd ${TMP} \
   && wget -q "https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_VERSION}/${minimal_sdk_file_name}.tar.xz" \
   && tar xvfJ ${minimal_sdk_file_name}.tar.xz \
   && mv zephyr-sdk-${ZEPHYR_SDK_VERSION} /opt/ \


### PR DESCRIPTION
When running `pip3 install --user -r zephyr/scripts/requirements.txt` (last step on https://zmk.dev/docs/development/setup), grpcio install fails with the following error:

    FileNotFoundError: [Errno 2] No such file or directory: c++: c++

This happens due to missing dev tooling in the container.

---

This is functionally equivalent to https://github.com/zmkfirmware/zmk/pull/2216 . It was suggested in that MR that the best place for this fix would be this repository instead. If that's the case, if and when this MR is merged, that one can be closed.