### PR TITLE
fix: Force CMake 3 pip package to bring in CMake 3.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN \
   ssh \
   && PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install \
   -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-base.txt \
-  && PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install cmake protobuf~=5.29 grpcio-tools \
+  && PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install cmake==3.31.6 protobuf~=5.29 grpcio-tools \
   && apt-get remove -y --purge \
   g++ \
   python3-dev \


### PR DESCRIPTION
Some Zephyr CMake pieces require CMake 3.5 compatability, which is removed in CMake 4, so force the CMake 3 python package, which brings in a local CMake v3 to go with it.