### PR TITLE
fix: drop pip cache and leftover hosttools installer from images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ RUN \
   python3-setuptools \
   python3-wheel \
   ssh \
-  && PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install \
+  && PIP_BREAK_SYSTEM_PACKAGES=1 PIP_NO_CACHE_DIR=1 pip3 install \
   -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-base.txt \
-  && PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install cmake==3.31.6 protobuf~=5.29 grpcio-tools \
+  && PIP_BREAK_SYSTEM_PACKAGES=1 PIP_NO_CACHE_DIR=1 pip3 install cmake==3.31.6 protobuf~=5.29 grpcio-tools \
   && apt-get remove -y --purge \
   g++ \
   python3-dev \
@@ -73,7 +73,7 @@ RUN \
   tio \
   wget \
   xz-utils \
-  && PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install \
+  && PIP_BREAK_SYSTEM_PACKAGES=1 PIP_NO_CACHE_DIR=1 pip3 install \
   -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-build-test.txt \
   -r https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/v${ZEPHYR_VERSION}/scripts/requirements-run-test.txt \
   && apt-get clean \
@@ -106,6 +106,7 @@ RUN \
   && rm ${minimal_sdk_file_name}.tar.xz \
   && cd /opt/zephyr-sdk-${ZEPHYR_SDK_VERSION} \
   && ./setup.sh -h -c -t ${ARCHITECTURE}${arch_sep}zephyr-${arch_format} \
+  && rm -f zephyr-sdk-*-hosttools-standalone-*.sh \
   && cd \
   && apt-get remove -y --purge \
   wget \


### PR DESCRIPTION
Measured in the published `zmk-build-arm:stable` image (arm64):

1. **pip wheel cache (45 MB)** — every `pip3 install` runs without `--no-cache-dir`, so wheels accumulate under `/root/.cache/pip`. In the `common` stage `python3-pip` is purged in the same layer, so the cache can never be reused; it is pure layer weight. This PR adds command-scoped `PIP_NO_CACHE_DIR=1` to all three installs (not an `ENV`, so interactive use of the dev images still gets pip caching).
2. **Hosttools installer archive (43 MB)** — `setup.sh -h` downloads `zephyr-sdk-*-hosttools-standalone-*.sh` into the SDK dir, extracts it, and leaves the archive behind. Nothing consumes it afterwards. This PR deletes it right after `setup.sh`.

## Measured result

`zmk-build-arm` image store size: **660,954,283 → 581,807,033 bytes (−79 MB, −12%)** of compressed pull. Uncompressed layer content verified gone via `du`: `/root/.cache/pip` (45 MB) and `zephyr-sdk-aarch64-hosttools-standalone-0.9.sh` (43 MB).

## Verification

Built `--target build` with CI's args (`ZEPHYR_VERSION=4.1.0`, `ARCHITECTURE=arm`, `ZEPHYR_SDK_VERSION=0.16.9`) on arm64, then inside the dieted image:

- `west`, `cmake`, `ccache`, `gcc` all present; SDK `arm-zephyr-eabi-gcc` compiles+links a bare-metal binary; all version probes identical to `:stable` (gcc 12.2.0, west v1.5.0, cmake 3.31.6)
- Real firmware build succeeds end-to-end: `west build -s app -b nice_nano/nrf52840/zmk -- -DSHIELD=corne_left` against current ZMK main → `zmk.uf2` produced (FLASH 28.43%, RAM 19.88%)

No functional change.

Made with [Cursor](https://cursor.com)